### PR TITLE
Reduce Cookie Validity

### DIFF
--- a/controllers/UserController.js
+++ b/controllers/UserController.js
@@ -183,9 +183,9 @@ router.post("/login", oAuth, async (req, res) => {
 
     res.cookie("token", apiToken, {
       httpOnly: true,
-      maxAge: 2592000000,
+      maxAge: 432000000,
       sameSite: true,
-    }); // Expires in 30 days
+    }); // Expires in 5 days
   } catch (e) {
     req.app.Sentry.captureException(e);
     res.stdRes.ret_det = e;


### PR DESCRIPTION
## [Reduce Cookie Validity]

---

### Summary

- Reduces the length of time that ZAB cookies are valid from 30 days to 5 days.

---

### Testing

1. Logout
2. Login
3. Verify cookie expiration is 5 days from the login time.

---

### Post-Deployment Validation

Testing 1-3.

---
