### PR TITLE
[#22] Add Missing Activity Check Before Inactive Notice Email

### DIFF
--- a/helpers/controllerActivityHelper.js
+++ b/helpers/controllerActivityHelper.js
@@ -173,6 +173,12 @@ async function checkControllersNeedingRemoval() {
     }
 }
 
+/**
+ * Determines which controllers are inactive from a list and returns inactivity data of those controllers.
+ * @param controllersToGetStatusFor A list of users to check the activity of.
+ * @param minActivityDate The start date of the activity period.
+ * @return A map of inactive controllers with the amount of hours they've controlled in the current period.
+ */
 async function getControllerInactivityData(controllersToGetStatusFor, minActivityDate) {
     const controllerHoursSummary = {};
     const controllerTrainingSummary = {};
@@ -232,6 +238,14 @@ async function getControllerInactivityData(controllersToGetStatusFor, minActivit
     return inactiveControllers;
 }
 
+/**
+ * Determines if a controller meets activity requirements based on the information provided.
+ * @param user The user to check for inactivity.
+ * @param hoursInPeriod The hours the controller controlled in this activity window.
+ * @param trainingSessionInPeriod The number of training sessions the user scheduled in this period.
+ * @param minActivityDate The start date of the activity period.
+ * @return True if controller is inactive, false otherwise.
+ */
 function controllerIsInactive(user, hoursInPeriod, trainingSessionInPeriod, minActivityDate) {
     const controllerHasLessThanTwoHours = (hoursInPeriod ?? 0) < requiredHoursPerPeriod;
     const controllerJoinedMoreThan60DaysAgo = (user.joinDate ?? user.createdAt) < minActivityDate;

--- a/helpers/controllerActivityHelper.js
+++ b/helpers/controllerActivityHelper.js
@@ -25,8 +25,8 @@ const redisActivityCheckKey = "ACTIVITYCHECKRUNNING";
  */
 function registerControllerActivityChecking() {
     try {
-        if (process.env.NODE_ENV !== 'prod') {
-            cron.schedule('* * * * *', async () => {
+        if (process.env.NODE_ENV === 'prod') {
+            cron.schedule('0 0 * * *', async () => {
                 // Lock the activity check to avoid multiple app instances trying to simulatenously run the check.
                 const lockRunningActivityCheck = await redisLock(redisActivityCheckKey);
 
@@ -72,13 +72,12 @@ async function checkControllerActivity() {
             await User.updateOne(
                 { "cid": record.user.cid },
                 {
-                    removalWarningDeliveryDate: today.plus({ minutes: 2 })
+                    removalWarningDeliveryDate: today.plus({ days: gracePeriodInDays })
                 }
             )
 
             transporter.sendMail({
-                to: "cdconn00@gmail.com",
-                //to: record.user.email,
+                to: record.user.email,
                 from: {
                     name: "Albuquerque ARTCC",
                     address: 'noreply@zabartcc.org'
@@ -152,8 +151,8 @@ async function checkControllersNeedingRemoval() {
 
             if (controllerIsInactive(user, userTotalHoursInPeriod, userTrainingRequestCount, minActivityDate)) {
                 transporter.sendMail({
-                    to: "cdconn00@gmail.com",
-                    //cc: 'datm@zabartcc.org',
+                    to: user.email,
+                    cc: 'datm@zabartcc.org',
                     from: {
                         name: "Albuquerque ARTCC",
                         address: 'noreply@zabartcc.org'


### PR DESCRIPTION
## [#22] Add Missing Activity Check Before Inactive Notice Email

---

### Summary
Previously, the email logic would send an inactivity notice to controllers after the grace period regardless if they actually made up the hours or not.

- Adds logic to check if the controller controlled in the grace period, and optionally not send them an inactivity notice. 
- Resets the check time back to 0z

---

### Testing

1. Previously verified in the beta environment.

---

### Post-Deployment Validation

1. Verify with the DATM they're being CC'd on the correct emails.

---
