### PR TITLE
Allow EC Read Feedback Access

### DIFF
--- a/controllers/FeedbackController.js
+++ b/controllers/FeedbackController.js
@@ -6,7 +6,7 @@ import Notification from '../models/Notification.js';
 import getUser from '../middleware/getUser.js';
 import auth from '../middleware/auth.js';
 
-router.get('/', getUser, auth(['atm', 'datm', 'ta']), async (req, res) => { // All feedback
+router.get('/', getUser, auth(['atm', 'datm', 'ta', 'ec']), async (req, res) => { // All feedback
 	try {
 		const page = +req.query.page || 1;
 		const limit = +req.query.limit || 20;
@@ -85,7 +85,7 @@ router.get('/controllers', async ({res}) => { // Controller list on feedback pag
 	return res.json(res.stdRes);
 });
 
-router.get('/unapproved', getUser, auth(['atm', 'datm', 'ta']), async ({res}) => { // Get all unapproved feedback
+router.get('/unapproved', getUser, auth(['atm', 'datm', 'ta', 'ec']), async ({res}) => { // Get all unapproved feedback
 	try {
 		const feedback = await Feedback.find({deletedAt: null, approved: false}).populate('controller', 'fname lname cid').sort({createdAt: 'desc'}).lean();
 		res.stdRes.data = feedback;


### PR DESCRIPTION
## Allow EC Read Feedback Access

---

### Summary

- Allows EC to read feedback, but not edit it.
- Closes https://github.com/zabartcc/issue-reporting/issues/13
---

### Testing

1. Take the EC role.
2. Verify you can view feedback.
3. Verify you have no buttons to approve/deny feedback.

---

### Post-Deployment Validation

- Repeat testing.

---

Has companion PR https://github.com/zabartcc/ui/pull/69 needs to be merged simulatenously.